### PR TITLE
fix: upgrade CI to Python 3.12 and fix parallel test race conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache pip dependencies
         uses: actions/cache@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -268,7 +268,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install protobuf
         run: brew install protobuf
@@ -295,7 +295,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install protobuf
         run: choco install protoc
@@ -392,17 +392,17 @@ jobs:
     if: always() && inputs.dry_run != true && (needs.publish-testpypi.result == 'success' || needs.publish-pypi.result == 'success')
     env:
       REGISTRY: ${{ needs.publish-testpypi.result == 'success' && 'testpypi' || 'pypi' }}
-      UV_PYTHON: "3.11"
+      UV_PYTHON: "3.12"
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Create virtualenv
-        run: uv venv --python 3.11
+        run: uv venv --python 3.12
 
       - name: Install published uni-db (with retry)
         env:

--- a/bindings/uni-db/tests/test_advanced.py
+++ b/bindings/uni-db/tests/test_advanced.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import sys
+import tempfile
 import unittest
 
 # Ensure we can import the module from the current directory
@@ -11,16 +12,13 @@ import uni_db
 
 class TestAdvanced(unittest.TestCase):
     def setUp(self):
-        self.test_dir = "./test_db_adv"
-        if os.path.exists(self.test_dir):
-            shutil.rmtree(self.test_dir)
+        self.test_dir = tempfile.mkdtemp(prefix="test_db_adv_")
         self.db = uni_db.Database(self.test_dir)
         self.db.create_label("Entity")
 
     def tearDown(self):
         del self.db
-        if os.path.exists(self.test_dir):
-            shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def test_transaction_commit(self):
         tx = self.db.begin()

--- a/bindings/uni-db/tests/test_builder.py
+++ b/bindings/uni-db/tests/test_builder.py
@@ -4,6 +4,7 @@
 """Tests for DatabaseBuilder API."""
 
 import os
+import shutil
 import tempfile
 
 import pytest
@@ -27,7 +28,8 @@ class TestDatabaseBuilderOpenModes:
 
     def test_create_fails_if_exists(self):
         """Test that create() fails if database exists."""
-        with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = tempfile.mkdtemp()
+        try:
             path = os.path.join(tmpdir, "testdb")
             # Create first
             db1 = uni_db.DatabaseBuilder.create(path).build()
@@ -38,6 +40,8 @@ class TestDatabaseBuilderOpenModes:
             # Create again should fail
             with pytest.raises(OSError):
                 uni_db.DatabaseBuilder.create(path).build()
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
     def test_open_existing_database(self):
         """Test opening an existing database."""


### PR DESCRIPTION
- Bump all CI workflows from Python 3.11 to 3.12
- Fix test_advanced.py: replace hardcoded relative path ./test_db_adv with tempfile.mkdtemp() to eliminate xdist worker race conditions
- Fix test_builder.py::test_create_fails_if_exists: use mkdtemp + shutil.rmtree(ignore_errors=True) instead of TemporaryDirectory to avoid ENOTEMPTY propagation on Python 3.11 during concurrent cleanup