### PR TITLE
fix(fts): prefilter filtered full-text searches

### DIFF
--- a/crates/uni-store/src/backend/lance.rs
+++ b/crates/uni-store/src/backend/lance.rs
@@ -938,6 +938,8 @@ impl StorageBackend for LanceDbBackend {
 
         if !filter.is_trivially_true() {
             let sql = filter.to_sql()?;
+            // Prefilter so excluded rows do not consume the FTS top-k slots.
+            scanner.prefilter(true);
             scanner
                 .filter(&sql)
                 .map_err(|e| anyhow!("FTS filter '{}' on '{}': {}", sql, table, e))?;

--- a/crates/uni/tests/common/vector_search/fts_integration.rs
+++ b/crates/uni/tests/common/vector_search/fts_integration.rs
@@ -529,3 +529,71 @@ async fn test_fts_query_score_increases_with_relevance() -> Result<()> {
 
     Ok(())
 }
+
+/// A filtered FTS query must apply its predicate before the top-k limit.
+///
+/// The excluded documents deliberately score higher than the matching
+/// documents, so applying the filter after the FTS limit starves the result.
+/// Regression for #194.
+#[tokio::test]
+async fn test_filtered_fts_query_prefilters_before_k() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dir = tempdir()?;
+    let path = dir.path();
+    let schema_manager = SchemaManager::load(&path.join("schema.json")).await?;
+    schema_manager.add_label("Doc")?;
+    schema_manager.add_property("Doc", "body", DataType::String, false)?;
+    schema_manager.add_property("Doc", "tag", DataType::String, false)?;
+    schema_manager.save().await?;
+
+    let db = uni_db::Uni::open(path.to_str().unwrap()).build().await?;
+
+    let tx = db.session().tx().await?;
+    tx.execute(
+        "UNWIND range(0, 49) AS i \
+         CREATE (:Doc {tag: 'drop', body: 'gamma gamma gamma gamma gamma drop-' + toString(i)})",
+    )
+    .await?;
+    tx.execute(
+        "UNWIND range(0, 49) AS i \
+         CREATE (:Doc {tag: 'keep', body: 'gamma filler filler filler filler keep-' + toString(i)})",
+    )
+    .await?;
+    tx.commit().await?;
+    db.flush().await?;
+
+    let tx = db.session().tx().await?;
+    tx.execute("CREATE FULLTEXT INDEX doc_body_fts FOR (d:Doc) ON EACH [d.body]")
+        .await?;
+    tx.commit().await?;
+
+    let result = db
+        .session()
+        .query(
+            "CALL uni.fts.query('Doc', 'body', 'gamma', 10, \"tag = 'keep'\", null, {}) \
+             YIELD node \
+             RETURN node.tag AS tag",
+        )
+        .await?;
+
+    let tags: Vec<String> = result
+        .rows()
+        .iter()
+        .map(|row| {
+            row.get("tag")
+                .map_err(|error| anyhow::anyhow!(error.to_string()))
+        })
+        .collect::<Result<_>>()?;
+    assert_eq!(
+        tags.len(),
+        10,
+        "filtered FTS should fill all requested slots"
+    );
+    assert!(
+        tags.iter().all(|tag| tag == "keep"),
+        "filtered FTS returned excluded rows: {tags:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #194

## Summary

Prevent filtered full-text searches from returning fewer than `k` results when excluded rows rank ahead of valid matches.

## Problem

`LanceDbBackend::full_text_search` applied the full-text-search top-k limit before applying the filter. A filtered query could therefore discard all valid matches when excluded rows consumed the top-k slots, as shown by the 100-document reproduction in #194.

## Changes

- Enable Lance prefiltering whenever an FTS filter is present so excluded rows do not consume top-k slots.
- Add a regression test using the adversarial corpus from #194 and assert that 10 filtered `keep` rows are returned.

## Compatibility

FTS query arguments and results for existing callers are unchanged. Unfiltered searches keep their existing behavior. Filtered searches now return complete up-to-k results when enough matching rows exist. No new dependencies or public API changes are introduced.

## Validation

- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo nextest run --offline -p uni-db --test integration -E 'test(test_filtered_fts_query_prefilters_before_k)'` — compiled the focused target, but runtime validation could not complete on Windows because the existing FTS integration path fails at transaction commit with `Internal error: Access is denied (os error 5)`. The unchanged `test_fts_auto_build_on_create_index` reproduces the same host failure.
- `cargo clippy --workspace --all-targets -- -D warnings` — could not complete on Windows because the existing workspace dependency `objc2` emits its platform guard for non-Apple targets; no warning from the changed Rust code was reported.

## Screenshots / Recordings

N/A
